### PR TITLE
Favor method calls over public properties on view classes

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,6 @@ php:
   - 5.6
   - 5.5
   - 5.4
-  - 5.3
   - hhvm
 before_script: composer install --dev
 script: php vendor/phpunit/phpunit/phpunit.php --log-tap report.tap

--- a/spec/watoki/tempan/DynamicValuesTest.php
+++ b/spec/watoki/tempan/DynamicValuesTest.php
@@ -94,6 +94,23 @@ class DynamicValuesTest extends Test {
         $this->thenTheResultShouldBe('<div property="say" data-what="Hello World">Hello World</div>');
     }
 
+    public function testFavorMethods() {
+        $this->givenTheClass('class PrivateAttribute {
+            private $value;
+            public function __construct($int) {
+                $this->value = $int;
+            }
+            public function value() {
+                return $this->value . "!";
+            }
+        }');
+
+        $this->givenTheModelIsInstanceOfClass('PrivateAttribute', 'foo');
+
+        $this->whenIRender('<div property="value"></div>');
+        $this->thenTheResultShouldBe('<div property="value">foo!</div>');
+    }
+
     ###############################################################################################################
 
     private function givenTheClass($def) {

--- a/src/watoki/tempan/Animator.php
+++ b/src/watoki/tempan/Animator.php
@@ -157,8 +157,8 @@ class Animator {
     private function hasModelField($model, $field) {
         return (is_array($model) && array_key_exists($field, $model))
                 || ($model instanceof Map && $model->has($field))
-                || (is_object($model) && property_exists($model, $field))
-                || (is_object($model) && method_exists($model, $field));
+                || (is_object($model) && method_exists($model, $field))
+                || (is_object($model) && property_exists($model, $field));
     }
 
     private function getModelField($model, $field, Element $element) {
@@ -175,13 +175,13 @@ class Animator {
                 return $model[$field];
             }
         } else if (is_object($model)) {
-            if (property_exists($model, $field)) {
+            if (method_exists($model, $field)) {
+                return $this->invoke([$model, $field], $element);
+            } else if (property_exists($model, $field)) {
                 if (!is_string($model->$field) && is_callable($model->$field)) {
                     return $this->invoke($model->$field, $element);
                 }
                 return $model->$field;
-            } else if (method_exists($model, $field)) {
-                return $this->invoke(array($model, $field), $element);
             }
         }
         return null;


### PR DESCRIPTION
The current implementation of tempan favors public properties over methods. Since this happens implicitly in the code, that will pose a problem if a public method paired with a private attribute is in use as the following example demonstrates:

``` php
class SampleView {
    private $foo;
    // ....
    public function foo() {
        return htmlentities($this->foo);
   }
}
```

Currently tempan would try to access the private property - which of course would fail.
This PR fixes that by favoring methods over properties.

I don't believe that this change would have any negative side effects as I deem it unlikely to have the reversed visibility (private methods and public attributes) within one class. For all other cases, the change should not have any practical impact, except that the method_exists call might be considered expensive and useless if only public properties are in use. If that is considered a problem, we might consider to refactor this code to have explicit Resolvers.
